### PR TITLE
added header search path

### DIFF
--- a/ios/YouTubeSdk.xcodeproj/project.pbxproj
+++ b/ios/YouTubeSdk.xcodeproj/project.pbxproj
@@ -242,6 +242,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -263,6 +264,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";


### PR DESCRIPTION
First of all, thank you so much for making such a good library.
I hope this library becomes an alternative to the existing library(react-native-youtube)!

For react-native 0.60 React Libs are installed by pod
and this header search path has to be included 
when installing manually